### PR TITLE
feat: 動的サイトマップ生成機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ node_modules/*
 dist/
 
 robots.txt
-sitemap*
 tsconfig.tsbuildinfo

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,35 @@
+import { MetadataRoute } from 'next'
+
+export const dynamic = 'force-static'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_DOMAIN_URL || 'http://localhost:3000'
+
+  // 静的ページ
+  const staticPages = [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/privacy`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+  ]
+
+  // 動的ページ（都道府県ページ 1-47）
+  const prefecturePages = Array.from({ length: 47 }, (_, i) => i + 1).map(
+    (id) => ({
+      url: `${baseUrl}/prefectures/${id}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    }),
+  )
+
+  return [...staticPages, ...prefecturePages]
+}


### PR DESCRIPTION
## LinearのチケットのURL
<!-- LinearのチケットURLを記載してください -->

## What（やったこと）
- Next.jsのMetadataRoute.Sitemapを使用した動的サイトマップ生成機能を実装
- 静的ページ（トップページ、プライバシーポリシー）と動的ページ（都道府県ページ1-47）を含むサイトマップを生成
- .gitignoreからsitemap*の除外を削除してビルド時にサイトマップが生成されるように修正

## Why（なぜやったか）
- SEO向上のため、検索エンジンがサイトの構造を理解しやすくする
- 都道府県ページが動的に生成されるため、手動でのサイトマップ管理が困難
- Next.jsの標準機能を活用してメンテナンス性を向上

## How（どうやったか）
- `src/app/sitemap.ts`を新規作成し、Next.jsのMetadataRoute.Sitemapを使用
- 静的ページと動的ページ（都道府県1-47）を配列で定義
- 各ページの優先度（0.7）と更新頻度（monthly）を設定
- .gitignoreからsitemap*の除外を削除

## 確認項目
- [ ] ビルド時にサイトマップが正常に生成される
- [ ] 生成されたサイトマップにすべてのページが含まれている
- [ ] サイトマップのXML形式が正しい
- [ ] 各ページの優先度と更新頻度が適切に設定されている

## 参照ドキュメント
- [Next.js Sitemap Documentation](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

🤖 Generated with Claude Code