### PR TITLE
fix: Material-UIの非推奨実装を最新の推奨実装に修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
-import Box from '@mui/system/Box'
-import Grid from '@mui/material/Grid'
+import Box from '@mui/material/Box'
+import Grid from '@mui/material/Grid2'
 import Divider from '@mui/material/Divider'
 
 import { getAllFinance } from '../lib/api'
@@ -57,9 +57,9 @@ export default async function HomePage() {
   return (
     <Layout>
       <Grid container spacing={6}>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Grid container spacing={3}>
-            <Grid item xs={12}>
+            <Grid size={12}>
               <Text
                 variant="h2"
                 align="center"
@@ -69,13 +69,13 @@ export default async function HomePage() {
                 「{CMS_NAME}」の使い方
               </Text>
 
-              <Text paragraph>
+              <Text sx={{ marginBottom: 2 }}>
                 政府統計から算出した全国の市区町村の財政力指数ランキングを掲載しています。
               </Text>
 
               <FinancePowerReference />
 
-              <Text paragraph>
+              <Text sx={{ marginBottom: 2 }}>
                 人口減少で地方の過疎化が進む現代、もし自治体が財政破綻すれば小中学校などの公共インフラは大きな影響を受けます。そうなる前に、移住先や今住んでいる市区町村の財政がわかれば準備ができます。
               </Text>
 
@@ -86,11 +86,11 @@ export default async function HomePage() {
           </Grid>
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Divider />
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Text
             variant="h2"
             align="center"
@@ -102,11 +102,11 @@ export default async function HomePage() {
           <DataReference />
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Divider />
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Text
             variant="h2"
             align="center"
@@ -118,12 +118,12 @@ export default async function HomePage() {
           <JapanMap />
         </Grid>
 
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Divider />
         </Grid>
 
-        <Grid item xs={12}>
-          <Box marginBottom={3}>
+        <Grid size={12}>
+          <Box sx={{ marginBottom: 3 }}>
             <Text variant="h2" gutterBottom>
               全国の財政力指数 TOP {maxSize}
             </Text>
@@ -151,11 +151,11 @@ export default async function HomePage() {
             requiredToolBar={false}
           />
         </Grid>
-        <Grid item xs={12}>
+        <Grid size={12}>
           <Divider />
         </Grid>
-        <Grid item xs={12}>
-          <Box marginBottom={3}>
+        <Grid size={12}>
+          <Box sx={{ marginBottom: 3 }}>
             <Text variant="h2" gutterBottom>
               全国の財政力指数 WORST {maxSize}
             </Text>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,22 +60,17 @@ export default async function HomePage() {
         <Grid size={12}>
           <Grid container spacing={3}>
             <Grid size={12}>
-              <Text
-                variant="h2"
-                align="center"
-                sx={{ fontWeight: 600 }}
-                gutterBottom
-              >
+              <Text variant="h2" align="center" sx={{ fontWeight: 600 }} gutterBottom>
                 「{CMS_NAME}」の使い方
               </Text>
 
-              <Text sx={{ marginBottom: 2 }}>
+              <Text sx={{ mb: 2 }}>
                 政府統計から算出した全国の市区町村の財政力指数ランキングを掲載しています。
               </Text>
 
               <FinancePowerReference />
 
-              <Text sx={{ marginBottom: 2 }}>
+              <Text sx={{ mb: 2 }}>
                 人口減少で地方の過疎化が進む現代、もし自治体が財政破綻すれば小中学校などの公共インフラは大きな影響を受けます。そうなる前に、移住先や今住んでいる市区町村の財政がわかれば準備ができます。
               </Text>
 
@@ -91,12 +86,7 @@ export default async function HomePage() {
         </Grid>
 
         <Grid size={12}>
-          <Text
-            variant="h2"
-            align="center"
-            sx={{ fontWeight: 600 }}
-            gutterBottom
-          >
+          <Text variant="h2" align="center" sx={{ fontWeight: 600 }} gutterBottom>
             データの参照元
           </Text>
           <DataReference />
@@ -107,12 +97,7 @@ export default async function HomePage() {
         </Grid>
 
         <Grid size={12}>
-          <Text
-            variant="h2"
-            align="center"
-            sx={{ fontWeight: 600 }}
-            gutterBottom
-          >
+          <Text variant="h2" align="center" sx={{ fontWeight: 600 }} gutterBottom>
             都道府県から探す
           </Text>
           <JapanMap />
@@ -123,7 +108,7 @@ export default async function HomePage() {
         </Grid>
 
         <Grid size={12}>
-          <Box sx={{ marginBottom: 3 }}>
+          <Box sx={{ mb: 3 }}>
             <Text variant="h2" gutterBottom>
               全国の財政力指数 TOP {maxSize}
             </Text>
@@ -155,7 +140,7 @@ export default async function HomePage() {
           <Divider />
         </Grid>
         <Grid size={12}>
-          <Box sx={{ marginBottom: 3 }}>
+          <Box sx={{ mb: 3 }}>
             <Text variant="h2" gutterBottom>
               全国の財政力指数 WORST {maxSize}
             </Text>

--- a/src/app/prefectures/[id]/page.tsx
+++ b/src/app/prefectures/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import * as React from 'react'
-import Box from '@mui/system/Box'
+import Box from '@mui/material/Box'
 
 import {
   getAllPrefectures,
@@ -51,7 +51,7 @@ export default async function PrefecturePage({
 
   return (
     <Layout>
-      <Box marginBottom={3}>
+      <Box sx={{ marginBottom: 3 }}>
         <Text variant="h1" bold gutterBottom>
           {prefecture.name}の財政力指数ランキング
         </Text>

--- a/src/app/prefectures/[id]/page.tsx
+++ b/src/app/prefectures/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function PrefecturePage({
 
   return (
     <Layout>
-      <Box sx={{ marginBottom: 3 }}>
+      <Box sx={{ mb: 3 }}>
         <Text variant="h1" bold gutterBottom>
           {prefecture.name}の財政力指数ランキング
         </Text>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -15,13 +15,13 @@ export default function PrivacyPage() {
   return (
     <Layout>
       <article>
-        <Text component="h1" variant="h4" paragraph bold>
+        <Text component="h1" variant="h4" sx={{ marginBottom: 2 }} bold>
           プライバシーポリシー
         </Text>
-        <Text paragraph>
+        <Text sx={{ marginBottom: 2 }}>
           このプライバシーポリシーは、当サイトが収集する情報、情報を収集する理由について理解を深めていただくためのものです。
         </Text>
-        <Box marginBottom={3}>
+        <Box sx={{ marginBottom: 3 }}>
           <Text component="h2" variant="h5" gutterBottom bold>
             個人情報の管理
           </Text>
@@ -40,7 +40,7 @@ export default function PrivacyPage() {
           </Text>
           個人情報が不要となった場合には、すみやかに廃棄します。
         </Box>
-        <Box marginBottom={3}>
+        <Box sx={{ marginBottom: 3 }}>
           <Text component="h2" variant="h5" gutterBottom bold>
             個人情報の第三者への提供について
           </Text>
@@ -52,14 +52,14 @@ export default function PrivacyPage() {
           <Text component="h3" variant="h6" gutterBottom bold>
             アナリティクス
           </Text>
-          <Text paragraph>
+          <Text sx={{ marginBottom: 2 }}>
             当サイトでは、Googleによるアクセス解析ツール「Googleアナリティクス」を利用しています。
           </Text>
-          <Text paragraph>
+          <Text sx={{ marginBottom: 2 }}>
             このGoogle アナリティクスはアクセス情報の収集のために
             Cookieを使用しています。このアクセス情報は匿名で収集されており、個人を特定するものではありません。
           </Text>
-          <Text paragraph>
+          <Text sx={{ marginBottom: 2 }}>
             Google アナリティクスの Cookie は、26
             ヶ月間保持されます。この機能はCookieを無効にすることで収集を拒否することが出来ますので、お使いのブラウザの設定をご確認ください。Google
             アナリティクスの利用規約に関して確認したい場合は、
@@ -68,7 +68,7 @@ export default function PrivacyPage() {
             </a>
             を確認してください。
           </Text>
-          <Text paragraph>
+          <Text sx={{ marginBottom: 2 }}>
             また、「ユーザーが Google パートナーのサイトやアプリを使用する際の
             Google によるデータ使用」に関して確認したい場合は、
             <a href="https://policies.google.com/technologies/partner-sites?hl=ja">
@@ -79,20 +79,20 @@ export default function PrivacyPage() {
           <Text component="h3" variant="h6" gutterBottom bold>
             免責事項
           </Text>
-          <Text paragraph>
+          <Text sx={{ marginBottom: 2 }}>
             当サイトからリンクやバナーなどによって他のサイトに移動された場合、移動先サイトで提供される情報、サービス等について一切の責任を負いません。
           </Text>
-          <Text paragraph>
+          <Text sx={{ marginBottom: 2 }}>
             当サイトのコンテンツ・情報につきまして、可能な限り正確な情報を掲載するよう努めておりますが、誤情報が入り込んだり、情報が古くなっていることもございます。
           </Text>
-          <Text paragraph>
+          <Text sx={{ marginBottom: 2 }}>
             当サイトに掲載された内容によって生じた損害等の一切の責任を負いかねますのでご了承ください。
           </Text>
-          <Text paragraph>
+          <Text sx={{ marginBottom: 2 }}>
             当サイトで掲載している画像の著作権・肖像権等は各権利所有者に帰属致します。権利を侵害する目的ではございません。記事の内容や掲載画像等に問題がございましたら、各権利所有者様本人が直接メールでご連絡下さい。確認後、対応させて頂きます。
           </Text>
         </Box>
-        <Box marginBottom={3}>
+        <Box sx={{ marginBottom: 3 }}>
           <Text component="h2" variant="h5" gutterBottom bold>
             プライバシーポリシーの変更について
           </Text>
@@ -100,7 +100,7 @@ export default function PrivacyPage() {
             当サイトは、個人情報に関して適用される日本の法令を遵守するとともに、本プライバシーポリシーの内容を適宜見直しその改善に努めます。修正された最新のプライバシーポリシーは常に本ページにて開示されます。
           </Text>
         </Box>
-        <Text paragraph>2022 年 7 月 25 日　策定</Text>
+        <Text sx={{ marginBottom: 2 }}>2022 年 7 月 25 日　策定</Text>
       </article>
     </Layout>
   )

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -15,13 +15,13 @@ export default function PrivacyPage() {
   return (
     <Layout>
       <article>
-        <Text component="h1" variant="h4" sx={{ marginBottom: 2 }} bold>
+        <Text component="h1" variant="h4" sx={{ mb: 2 }} bold>
           プライバシーポリシー
         </Text>
-        <Text sx={{ marginBottom: 2 }}>
+        <Text sx={{ mb: 2 }}>
           このプライバシーポリシーは、当サイトが収集する情報、情報を収集する理由について理解を深めていただくためのものです。
         </Text>
-        <Box sx={{ marginBottom: 3 }}>
+        <Box sx={{ mb: 3 }}>
           <Text component="h2" variant="h5" gutterBottom bold>
             個人情報の管理
           </Text>
@@ -40,7 +40,7 @@ export default function PrivacyPage() {
           </Text>
           個人情報が不要となった場合には、すみやかに廃棄します。
         </Box>
-        <Box sx={{ marginBottom: 3 }}>
+        <Box sx={{ mb: 3 }}>
           <Text component="h2" variant="h5" gutterBottom bold>
             個人情報の第三者への提供について
           </Text>
@@ -52,14 +52,14 @@ export default function PrivacyPage() {
           <Text component="h3" variant="h6" gutterBottom bold>
             アナリティクス
           </Text>
-          <Text sx={{ marginBottom: 2 }}>
+          <Text sx={{ mb: 2 }}>
             当サイトでは、Googleによるアクセス解析ツール「Googleアナリティクス」を利用しています。
           </Text>
-          <Text sx={{ marginBottom: 2 }}>
+          <Text sx={{ mb: 2 }}>
             このGoogle アナリティクスはアクセス情報の収集のために
             Cookieを使用しています。このアクセス情報は匿名で収集されており、個人を特定するものではありません。
           </Text>
-          <Text sx={{ marginBottom: 2 }}>
+          <Text sx={{ mb: 2 }}>
             Google アナリティクスの Cookie は、26
             ヶ月間保持されます。この機能はCookieを無効にすることで収集を拒否することが出来ますので、お使いのブラウザの設定をご確認ください。Google
             アナリティクスの利用規約に関して確認したい場合は、
@@ -68,7 +68,7 @@ export default function PrivacyPage() {
             </a>
             を確認してください。
           </Text>
-          <Text sx={{ marginBottom: 2 }}>
+          <Text sx={{ mb: 2 }}>
             また、「ユーザーが Google パートナーのサイトやアプリを使用する際の
             Google によるデータ使用」に関して確認したい場合は、
             <a href="https://policies.google.com/technologies/partner-sites?hl=ja">
@@ -79,20 +79,20 @@ export default function PrivacyPage() {
           <Text component="h3" variant="h6" gutterBottom bold>
             免責事項
           </Text>
-          <Text sx={{ marginBottom: 2 }}>
+          <Text sx={{ mb: 2 }}>
             当サイトからリンクやバナーなどによって他のサイトに移動された場合、移動先サイトで提供される情報、サービス等について一切の責任を負いません。
           </Text>
-          <Text sx={{ marginBottom: 2 }}>
+          <Text sx={{ mb: 2 }}>
             当サイトのコンテンツ・情報につきまして、可能な限り正確な情報を掲載するよう努めておりますが、誤情報が入り込んだり、情報が古くなっていることもございます。
           </Text>
-          <Text sx={{ marginBottom: 2 }}>
+          <Text sx={{ mb: 2 }}>
             当サイトに掲載された内容によって生じた損害等の一切の責任を負いかねますのでご了承ください。
           </Text>
-          <Text sx={{ marginBottom: 2 }}>
+          <Text sx={{ mb: 2 }}>
             当サイトで掲載している画像の著作権・肖像権等は各権利所有者に帰属致します。権利を侵害する目的ではございません。記事の内容や掲載画像等に問題がございましたら、各権利所有者様本人が直接メールでご連絡下さい。確認後、対応させて頂きます。
           </Text>
         </Box>
-        <Box sx={{ marginBottom: 3 }}>
+        <Box sx={{ mb: 3 }}>
           <Text component="h2" variant="h5" gutterBottom bold>
             プライバシーポリシーの変更について
           </Text>
@@ -100,7 +100,7 @@ export default function PrivacyPage() {
             当サイトは、個人情報に関して適用される日本の法令を遵守するとともに、本プライバシーポリシーの内容を適宜見直しその改善に努めます。修正された最新のプライバシーポリシーは常に本ページにて開示されます。
           </Text>
         </Box>
-        <Text sx={{ marginBottom: 2 }}>2022 年 7 月 25 日　策定</Text>
+        <Text sx={{ mb: 2 }}>2022 年 7 月 25 日　策定</Text>
       </article>
     </Layout>
   )

--- a/src/components/projects/DataReference/index.tsx
+++ b/src/components/projects/DataReference/index.tsx
@@ -1,4 +1,4 @@
-import Box from '@mui/system/Box'
+import Box from '@mui/material/Box'
 
 import { DATA_YEAR, JAPANESE_YEAR } from '../../../lib/constants'
 import Alert from '../../uiParts/Alert'
@@ -6,7 +6,7 @@ import Text from '../../uiParts/Text'
 
 const Reference = () => (
   <>
-    <Box marginBottom={3}>
+    <Box sx={{ marginBottom: 3 }}>
       <Text gutterBottom>下記の政府統計を使用しています。</Text>
       <Text variant="body2" gutterBottom>
         <a href="https://www.soumu.go.jp/iken/zaisei/R04_chiho.html">
@@ -19,7 +19,7 @@ const Reference = () => (
         </a>
       </Text>
     </Box>
-    <Box marginBottom={3}>
+    <Box sx={{ marginBottom: 3 }}>
       <Alert title="地方財政状況調査とは">
         <Text variant="body2" gutterBottom>
           都道府県や市町村など各地方公共団体の決算に関する統計調査で、統一的な会計区分が定められ予算の執行を通じて地方公共団体がどのように行政運営を行ったかを見るものです。

--- a/src/components/projects/DataReference/index.tsx
+++ b/src/components/projects/DataReference/index.tsx
@@ -6,7 +6,7 @@ import Text from '../../uiParts/Text'
 
 const Reference = () => (
   <>
-    <Box sx={{ marginBottom: 3 }}>
+    <Box sx={{ mb: 3 }}>
       <Text gutterBottom>下記の政府統計を使用しています。</Text>
       <Text variant="body2" gutterBottom>
         <a href="https://www.soumu.go.jp/iken/zaisei/R04_chiho.html">
@@ -19,7 +19,7 @@ const Reference = () => (
         </a>
       </Text>
     </Box>
-    <Box sx={{ marginBottom: 3 }}>
+    <Box sx={{ mb: 3 }}>
       <Alert title="地方財政状況調査とは">
         <Text variant="body2" gutterBottom>
           都道府県や市町村など各地方公共団体の決算に関する統計調査で、統一的な会計区分が定められ予算の執行を通じて地方公共団体がどのように行政運営を行ったかを見るものです。

--- a/src/components/projects/FinancePowerReference/index.tsx
+++ b/src/components/projects/FinancePowerReference/index.tsx
@@ -4,7 +4,7 @@ import Alert from '../../uiParts/Alert'
 import Text from '../../uiParts/Text'
 
 const FinancePowerReference = () => (
-  <Box sx={{ marginBottom: 3 }}>
+  <Box sx={{ mb: 3 }}>
     <Alert title="財政力指数とは">
       <Text variant="body2" gutterBottom>
         地方公共団体の財政力を示す指数です。基準財政収入額を基準財政需要額で割った数値の過去3年間の平均です。

--- a/src/components/projects/FinancePowerReference/index.tsx
+++ b/src/components/projects/FinancePowerReference/index.tsx
@@ -1,10 +1,10 @@
-import Box from '@mui/system/Box'
+import Box from '@mui/material/Box'
 
 import Alert from '../../uiParts/Alert'
 import Text from '../../uiParts/Text'
 
 const FinancePowerReference = () => (
-  <Box marginBottom={3}>
+  <Box sx={{ marginBottom: 3 }}>
     <Alert title="財政力指数とは">
       <Text variant="body2" gutterBottom>
         地方公共団体の財政力を示す指数です。基準財政収入額を基準財政需要額で割った数値の過去3年間の平均です。

--- a/src/components/uiParts/Footer/index.tsx
+++ b/src/components/uiParts/Footer/index.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import React from 'react'
-import Grid from '@mui/material/Grid'
+import Grid from '@mui/material/Grid2'
 import Divider from '@mui/material/Divider'
 import Typography from '@mui/material/Typography'
 
@@ -19,12 +19,12 @@ const Footer = () => {
         className={classes['footer']}
         spacing={2}
       >
-        <Grid item>
+        <Grid>
           <Typography variant="body2">
             <Link href="/privacy/">プライバシーポリシー</Link>
           </Typography>
         </Grid>
-        <Grid item>
+        <Grid>
           <Typography variant="body2">
             <a
               href="https://docs.google.com/forms/d/e/1FAIpQLSeFs26WtYyW1_nFo75FUnZrD0UIUcZQUqLT8fc8XbcPk8P2MQ/viewform?usp=sf_link"
@@ -35,14 +35,14 @@ const Footer = () => {
             </a>
           </Typography>
         </Grid>
-        <Grid item>
+        <Grid>
           <Typography variant="body2">
             <a href="https://www.komtaki.com" target="_blank" rel="noreferrer">
               開発者のブログ
             </a>
           </Typography>
         </Grid>
-        <Grid item xs={12} className={classes['footer__copyright']}>
+        <Grid size={12} className={classes['footer__copyright']}>
           <Typography variant="caption">
             ©2022 city-finance.komtaki.com
           </Typography>

--- a/src/components/uiParts/Layout/index.tsx
+++ b/src/components/uiParts/Layout/index.tsx
@@ -16,7 +16,7 @@ const Container: React.FC<Props> = ({ children }) => {
     <>
       <Header />
       <MuiContainer maxWidth="md">
-        <Box sx={{ marginTop: 3, marginBottom: 3 }}>{children}</Box>
+        <Box sx={{ mt: 3, mb: 3 }}>{children}</Box>
       </MuiContainer>
       <Footer />
     </>

--- a/src/components/uiParts/Layout/index.tsx
+++ b/src/components/uiParts/Layout/index.tsx
@@ -16,9 +16,7 @@ const Container: React.FC<Props> = ({ children }) => {
     <>
       <Header />
       <MuiContainer maxWidth="md">
-        <Box marginTop={3} marginBottom={3}>
-          {children}
-        </Box>
+        <Box sx={{ marginTop: 3, marginBottom: 3 }}>{children}</Box>
       </MuiContainer>
       <Footer />
     </>

--- a/src/components/uiParts/Text/index.tsx
+++ b/src/components/uiParts/Text/index.tsx
@@ -8,8 +8,8 @@ type Props = TypographyProps & {
   component?: string
 }
 
-const Text: React.FC<Props> = ({ children, bold = false, ...props }) => (
-  <Typography {...props} sx={bold ? { fontWeight: 600 } : {}}>
+const Text: React.FC<Props> = ({ children, bold = false, sx, ...props }) => (
+  <Typography {...props} sx={[bold ? { fontWeight: 600 } : {}, ...(Array.isArray(sx) ? sx : [sx])]}>
     {children}
   </Typography>
 )

--- a/src/components/uiParts/Text/index.tsx
+++ b/src/components/uiParts/Text/index.tsx
@@ -9,7 +9,7 @@ type Props = TypographyProps & {
 }
 
 const Text: React.FC<Props> = ({ children, bold = false, sx, ...props }) => (
-  <Typography {...props} sx={[bold ? { fontWeight: 600 } : {}, ...(Array.isArray(sx) ? sx : [sx])]}>
+  <Typography {...props} sx={bold ? { fontWeight: 600, ...sx } : sx}>
     {children}
   </Typography>
 )


### PR DESCRIPTION
## What(やったこと)

Material-UIの非推奨実装を最新の推奨実装に修正しました。

## Why(なぜやったか)

- MUI v5以降で非推奨になったAPIの使用により、将来の互換性に問題が生じる可能性があった
- 最新の推奨実装に移行することで、パフォーマンス向上とTypeScriptサポートの改善が期待できる
- 開発者体験の向上とコードの保守性を向上させるため

## How(どうやったか)

### 修正内容

1. **@mui/system/Box の統一**
   - @mui/system/Box → @mui/material/Box に変更
   - 影響ファイル: 4ファイル

2. **非推奨propsの修正**
   - marginTop, marginBottom props → sx プロパティに移行
   - 影響ファイル: 6ファイル

3. **Grid から Grid2 への移行**
   - @mui/material/Grid → @mui/material/Grid2 に変更
   - item xs={12} → size={12} に変更
   - 影響ファイル: 2ファイル

4. **Typography の paragraph prop 修正**
   - paragraph prop → sx={{ marginBottom: 2 }} に変更
   - 影響ファイル: 2ファイル

### 技術的詳細

- **Grid2の利点**: より効率的なレンダリング、改善されたTypeScriptサポート
- **sx プロパティ**: より柔軟で一貫性のあるスタイリング
- **互換性**: 既存のデザインとレイアウトは完全に維持

## 確認項目

- [x] リンターエラーなし
- [x] ビルド成功
- [x] すべてのページが正常に生成される
- [x] 既存の機能は維持されている
- [x] レイアウトは完全に維持されている

## 参照資料

- MUI v5 Migration Guide: https://mui.com/material-ui/migration/migrating-from-v4/
- Grid2 Documentation: https://mui.com/material-ui/react-grid2/
- sx prop Documentation: https://mui.com/system/getting-started/the-sx-prop/

🤖 Generated with Claude Code