### PR TITLE
chore: next-sitemapパッケージを削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "eslint": "9.37.0",
         "eslint-config-flat-gitignore": "^2.1.0",
         "eslint-config-next": "15.5.4",
-        "next-sitemap": "^4.2.3",
         "prettier": "^3.6.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
@@ -245,12 +244,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@corex/deepmerge": {
-      "version": "4.0.43",
-      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
-      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
-      "dev": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1351,12 +1344,6 @@
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/@next/env": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
-      "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==",
-      "dev": true
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "15.5.4",
@@ -4902,33 +4889,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-sitemap": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
-      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
-      "dev": true,
-      "funding": [
-        {
-          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
-        }
-      ],
-      "dependencies": {
-        "@corex/deepmerge": "^4.0.43",
-        "@next/env": "^13.4.3",
-        "fast-glob": "^3.2.12",
-        "minimist": "^1.2.8"
-      },
-      "bin": {
-        "next-sitemap": "bin/next-sitemap.mjs",
-        "next-sitemap-cjs": "bin/next-sitemap.cjs"
-      },
-      "engines": {
-        "node": ">=14.18"
-      },
-      "peerDependencies": {
-        "next": "*"
       }
     },
     "node_modules/next/node_modules/@next/env": {


### PR DESCRIPTION
## What (やったこと)
next-sitemapパッケージをpackage-lock.jsonから削除しました。

## Why (なぜやったか)
動的サイトマップ生成機能の実装により、next-sitemapパッケージが不要になったため削除しました。

## How (どうやったか)
- package-lock.jsonからnext-sitemapパッケージとその依存関係を削除
- 関連するnode_modulesのエントリも自動的に削除

## 確認項目
- [ ] コードの動作確認
- [ ] サイトマップ生成機能の動作確認
- [ ] 破壊的変更の有無確認

🤖 Generated with Claude Code