### PR TITLE
feat: Material-UIをv6からv7にメジャーアップグレード

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+/// <reference path="./dist/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "city-finance",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/material": "^6.5.0",
-        "@mui/x-data-grid": "^7.29.9",
+        "@mui/material": "^7.3.4",
+        "@mui/x-data-grid": "^8.13.1",
         "csv": "^6.4.1",
         "csv-parse": "^6.1.0",
         "next": "^15.5.4",
@@ -224,9 +225,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1084,9 +1085,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
-      "integrity": "sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.4.tgz",
+      "integrity": "sha512-BIktMapG3r4iXwIhYNpvk97ZfYWTreBBQTWjQKbNbzI64+ULHfYavQEX2w99aSWHS58DvXESWIgbD9adKcUOBw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1094,22 +1095,22 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
-      "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
+      "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/core-downloads-tracker": "^6.5.0",
-        "@mui/system": "^6.5.0",
-        "@mui/types": "~7.2.24",
-        "@mui/utils": "^6.4.9",
+        "@babel/runtime": "^7.28.4",
+        "@mui/core-downloads-tracker": "^7.3.4",
+        "@mui/system": "^7.3.3",
+        "@mui/types": "^7.4.7",
+        "@mui/utils": "^7.3.3",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0",
+        "react-is": "^19.1.1",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -1122,7 +1123,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^6.5.0",
+        "@mui/material-pigment-css": "^7.3.3",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1143,13 +1144,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
-      "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.3.tgz",
+      "integrity": "sha512-OJM+9nj5JIyPUvsZ5ZjaeC9PfktmK+W5YaVLToLR8L0lB/DGmv1gcKE43ssNLSvpoW71Hct0necfade6+kW3zQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/utils": "^6.4.9",
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1170,13 +1171,13 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.5.0.tgz",
-      "integrity": "sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.3.tgz",
+      "integrity": "sha512-CmFxvRJIBCEaWdilhXMw/5wFJ1+FT9f3xt+m2pPXhHPeVIbBg9MnMvNSJjdALvnQJMPw8jLhrUtXmN7QAZV2fw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@emotion/cache": "^11.13.5",
+        "@babel/runtime": "^7.28.4",
+        "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
         "csstype": "^3.1.3",
@@ -1204,16 +1205,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.5.0.tgz",
-      "integrity": "sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.3.tgz",
+      "integrity": "sha512-Lqq3emZr5IzRLKaHPuMaLBDVaGvxoh6z7HMWd1RPKawBM5uMRaQ4ImsmmgXWtwJdfZux5eugfDhXJUo2mliS8Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/private-theming": "^6.4.9",
-        "@mui/styled-engine": "^6.5.0",
-        "@mui/types": "~7.2.24",
-        "@mui/utils": "^6.4.9",
+        "@babel/runtime": "^7.28.4",
+        "@mui/private-theming": "^7.3.3",
+        "@mui/styled-engine": "^7.3.3",
+        "@mui/types": "^7.4.7",
+        "@mui/utils": "^7.3.3",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -1244,10 +1245,13 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.24",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
-      "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.7.tgz",
+      "integrity": "sha512-8vVje9rdEr1rY8oIkYgP+Su5Kwl6ik7O3jQ0wl78JGSmiZhRHV+vkjooGdKD8pbtZbutXFVTWQYshu2b3sG9zw==",
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -1258,17 +1262,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
-      "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.3.tgz",
+      "integrity": "sha512-kwNAUh7bLZ7mRz9JZ+6qfRnnxbE4Zuc+RzXnhSpRSxjTlSTj7b4JxRLXpG+MVtPVtqks5k/XC8No1Vs3x4Z2gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/types": "~7.2.24",
-        "@types/prop-types": "^15.7.14",
+        "@babel/runtime": "^7.28.4",
+        "@mui/types": "^7.4.7",
+        "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
+        "react-is": "^19.1.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1288,18 +1292,18 @@
       }
     },
     "node_modules/@mui/x-data-grid": {
-      "version": "7.29.9",
-      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.29.9.tgz",
-      "integrity": "sha512-RfK7Fnuu4eyv/4eD3MEB1xxZsx0xRBsofb1kifghIjyQV1EKAeRcwvczyrzQggj7ZRT5AqkwCzhLsZDvE5O0nQ==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-8.13.1.tgz",
+      "integrity": "sha512-64MlyukMoGEDLT3kqdm6tw+rocgMayChj+h+fdAwqD4+2NMQoD5wZElQE+xTNmU0/DPv710X4ENceBRt2hMuGw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
-        "@mui/x-internals": "7.29.0",
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.2",
+        "@mui/x-internals": "8.13.1",
+        "@mui/x-virtualizer": "0.2.2",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "reselect": "^5.1.1",
-        "use-sync-external-store": "^1.0.0"
+        "use-sync-external-store": "^1.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1326,13 +1330,15 @@
       }
     },
     "node_modules/@mui/x-internals": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
-      "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-8.13.1.tgz",
+      "integrity": "sha512-OKQyCJ9uxtMpjBZCOEQGOR5MhgL1f9HjI4qZHuaLxxtDATK5rcBbVjBF67hI8FzXeF1wrcZP2wsjc4AgGpAo9g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.2",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1343,6 +1349,28 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-virtualizer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-virtualizer/-/x-virtualizer-0.2.2.tgz",
+      "integrity": "sha512-+ZcGYh/9ykoEofzcAWcJ3n6TBXzCc2ETvytho30wRkYv1ez+8yps0ezns/QvC4JqXBge/3y+e+QatIYjkTltdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "@mui/utils": "^7.3.2",
+        "@mui/x-internals": "8.13.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1935,9 +1963,9 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -7779,9 +7807,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
-      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
+      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
       "license": "MIT"
     },
     "node_modules/react-transition-group": {
@@ -8417,9 +8445,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/material": "^6.5.0",
-    "@mui/x-data-grid": "^7.29.9",
+    "@mui/material": "^7.3.4",
+    "@mui/x-data-grid": "^8.13.1",
     "csv": "^6.4.1",
     "csv-parse": "^6.1.0",
     "next": "^15.5.4",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Box from '@mui/material/Box'
-import Grid from '@mui/material/Grid2'
+import Grid from '@mui/material/Grid'
 import Divider from '@mui/material/Divider'
 
 import { getAllFinance } from '../lib/api'
@@ -60,7 +60,12 @@ export default async function HomePage() {
         <Grid size={12}>
           <Grid container spacing={3}>
             <Grid size={12}>
-              <Text variant="h2" align="center" sx={{ fontWeight: 600 }} gutterBottom>
+              <Text
+                variant="h2"
+                align="center"
+                sx={{ fontWeight: 600 }}
+                gutterBottom
+              >
                 「{CMS_NAME}」の使い方
               </Text>
 
@@ -86,7 +91,12 @@ export default async function HomePage() {
         </Grid>
 
         <Grid size={12}>
-          <Text variant="h2" align="center" sx={{ fontWeight: 600 }} gutterBottom>
+          <Text
+            variant="h2"
+            align="center"
+            sx={{ fontWeight: 600 }}
+            gutterBottom
+          >
             データの参照元
           </Text>
           <DataReference />
@@ -97,7 +107,12 @@ export default async function HomePage() {
         </Grid>
 
         <Grid size={12}>
-          <Text variant="h2" align="center" sx={{ fontWeight: 600 }} gutterBottom>
+          <Text
+            variant="h2"
+            align="center"
+            sx={{ fontWeight: 600 }}
+            gutterBottom
+          >
             都道府県から探す
           </Text>
           <JapanMap />

--- a/src/components/uiParts/Footer/index.tsx
+++ b/src/components/uiParts/Footer/index.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import React from 'react'
-import Grid from '@mui/material/Grid2'
+import Grid from '@mui/material/Grid'
 import Divider from '@mui/material/Divider'
 import Typography from '@mui/material/Typography'
 


### PR DESCRIPTION
## What (やったこと)
Material-UIのメジャーバージョンアップを実行しました。

- @mui/material: 6.5.0 → 7.3.4
- @mui/x-data-grid: 7.29.9 → 8.13.1

## Why (なぜやったか)
- 最新の機能とセキュリティアップデートを享受するため
- 長期的なメンテナンス性を向上させるため
- 依存関係の脆弱性を解決するため

## How (どうやったか)
1. 現在のMUIバージョンを確認
2. 最新バージョンと破壊的変更を調査
3. package.jsonの依存関係を更新
4. Grid2コンポーネントをMUI v7の新しいGridコンポーネントに移行
5. MUI v7の新しいGridではitemプロパティが不要になり、sizeプロパティを維持
6. ビルドエラーを解決
7. セキュリティ脆弱性を修正

## 確認項目
- [x] ビルドが正常に完了する
- [x] 開発サーバーが正常に起動する
- [x] セキュリティ脆弱性が解決されている
- [x] 既存の機能が維持されている
- [x] MUI v7の新しいGridコンポーネントを正しく使用

## 参考資料
- [MUI v7 Release Notes](https://mui.com/material-ui/migration/migrating-from-v6/)
- [MUI Grid Migration Guide](https://mui.com/material-ui/react-grid/)

🤖 Generated with Claude Code